### PR TITLE
Fix for GPU not being disabled when in Intel graphics mode

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+gnome-shell-extension-system76-power (0.1.1) bionic; urgency=medium
+
+  * 0.1.1 release.
+
+ -- Jeremy Soller <jeremy@system76.com>  Mon, 14 May 2018 14:50:12 -0600
+
 gnome-shell-extension-system76-power (0.1.0) artful; urgency=medium
 
   * Initial release.

--- a/debian/control
+++ b/debian/control
@@ -11,6 +11,6 @@ Package: gnome-shell-extension-system76-power
 Architecture: all
 Depends:
     gnome-shell (>= 3.26.1),
-    system76-power,
+    system76-power (>= 0.1.1),
     ${misc:Depends}
 Description: Gnome-shell extension for System76 Power Management

--- a/extension.js
+++ b/extension.js
@@ -12,15 +12,22 @@ const Ornament = imports.ui.popupMenu.Ornament;
 const PowerDaemon = Gio.DBusProxy.makeProxyWrapper(
 '<node>\
   <interface name="com.system76.PowerDaemon">\
+    <method name="Performance"/>\
     <method name="Balanced"/>\
     <method name="Battery"/>\
     <method name="GetGraphics">\
       <arg name="vendor" type="s" direction="out"/>\
     </method>\
-    <method name="Performance"/>\
     <method name="SetGraphics">\
       <arg name="vendor" type="s" direction="in"/>\
     </method>\
+    <method name="GetGraphicsPower">\
+      <arg name="power" type="b" direction="out"/>\
+    </method>\
+    <method name="SetGraphicsPower">\
+      <arg name="power" type="b" direction="in"/>\
+    </method>\
+    <method name="AutoGraphicsPower"/>\
   </interface>\
 </node>'
 );

--- a/extension.js
+++ b/extension.js
@@ -30,6 +30,12 @@ function init() {}
 function enable() {
     this.bus = new PowerDaemon(Gio.DBus.system, 'com.system76.PowerDaemon', '/com/system76/PowerDaemon');
 
+    try {
+        this.bus.AutoGraphicsPowerSync()
+    } catch (error) {
+        global.log(error);
+    }
+
     this.powerMenu = Main.panel.statusArea['aggregateMenu']._power._item.menu;
 
     try {

--- a/extension.js
+++ b/extension.js
@@ -31,7 +31,7 @@ function enable() {
     this.bus = new PowerDaemon(Gio.DBus.system, 'com.system76.PowerDaemon', '/com/system76/PowerDaemon');
 
     try {
-        this.bus.AutoGraphicsPowerSync()
+        this.bus.AutoGraphicsPowerSync();
     } catch (error) {
         global.log(error);
     }


### PR DESCRIPTION
Requires https://github.com/pop-os/system76-power/pull/20

Disables the GPU when the extension is loaded, if possible