### PR TITLE
Update dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,6 @@ Vcs-Git: https://github.com/system76/gnome-shell-extension-system76-power.git
 Package: gnome-shell-extension-system76-power
 Architecture: all
 Depends:
-    gnome-shell (>= 3.26.1),
     system76-power (>= 0.1.2~),
     ${misc:Depends}
 Description: Gnome-shell extension for System76 Power Management


### PR DESCRIPTION
Remove gnome-shell as a dependency so if system76-driver (and therefore this gnome shell extension) are installed on a non-gnome machine, gnome-shell is not installed as well.