### PR TITLE
Discrete External Display Model Detection

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -45,7 +45,7 @@ var DISPLAY_REQUIRES_NVIDIA = false;
 function init() {
     let file = Gio.File.new_for_path (DMI_PRODUCT_VERSION_PATH);
     let [success, contents] = file.load_contents(null);
-    var product_version = contents.trim();
+    let product_version = contents.toString().trim();
     DISPLAY_REQUIRES_NVIDIA = DISCRETE_EXTERNAL_DISPLAY_MODELS.includes(product_version);
 }
 


### PR DESCRIPTION
This should fix the `Enable for external display` / `Disables external displays` power menu text for non-oryp4 models with switchable graphics. It should be tested on an oryp4 to see if the text still displays there -- the text will not display by default, unless `/sys/class/dmi/id/product_version` contains either `oryp4` or `oryp4-b`.