### PR TITLE
Fix reading file content

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -48,7 +48,7 @@ var DISPLAY_REQUIRES_NVIDIA = false;
 function init() {
     let file = Gio.File.new_for_path (DMI_PRODUCT_VERSION_PATH);
     let [success, contents] = file.load_contents(null);
-    let product_version = contents.toString().trim();
+    let product_version = (contents instanceof Uint8Array ? imports.byteArray.toString(contents) : contents.toString()).trim();
     DISPLAY_REQUIRES_NVIDIA = DISCRETE_EXTERNAL_DISPLAY_MODELS.includes(product_version);
 }
 


### PR DESCRIPTION
Hi, 
I found this stacktrace in my journalctl:
```
Some code called array.toString() on a Uint8Array instance. Previously this would have interpreted the bytes of the array as a string, but that is 
(Note that array.toString() may have been called implicitly.)
0 init() ["/usr/share/gnome-shell/extensions/system76-power@system76.com/extension.js":51]
1 initExtension() ["resource:///org/gnome/shell/ui/extensionSystem.js":249]
   ....
16 start() ["resource:///org/gnome/shell/ui/main.js":136]
17 <TOP LEVEL> ["<main>":1]
```

Ubuntu 18.10
Digging about it I found that:
https://gitlab.gnome.org/GNOME/gnome-shell/commit/112aac2214bc4728cd87cfe3819049a15994d4e1?view=inline

And I think that we could fix easy