### PR TITLE
Fix an error about converting a byte array into a string

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -54,7 +54,7 @@ var DISPLAY_REQUIRES_NVIDIA = false;
 function init() {
     let file = Gio.File.new_for_path(DMI_PRODUCT_VERSION_PATH);
     let [success, contents] = file.load_contents(null);
-    let product_version = contents.toString().trim();
+    let product_version = ByteArray.toString(contents).trim();
     DISPLAY_REQUIRES_NVIDIA = DISCRETE_EXTERNAL_DISPLAY_MODELS.includes(product_version);
 }
 


### PR DESCRIPTION
Fixes this error:

```
Some code called array.toString() on a Uint8Array instance. Previously this would have interpreted the bytes of the array as a string, but that is nonstandard. In the future this will return the bytes as comma-separated digits. For the time being, the old behavior has been preserved, but please fix your code anyway to explicitly call ByteArray.toString(array).
    (Note that array.toString() may have been called implicitly.)
    0 init() ["/usr/share/gnome-shell/extensions/system76-power@system76.com/extension.js":57]
```