### PR TITLE
Fix 'will be enabled' note in menu after switching graphics

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -306,13 +306,13 @@ function graphics_activate(item, name, vendor) {
                 dialog._content._body.set_text(_("Switching to ") + name + _(" will close all open apps and restart your device. You may lose any unsaved work."));
 
                 var reboot_msg = _("Will be enabled on\nthe next restart.");
-                if (name == "hybrid") {
+                if (name == "Hybrid") {
                     extension.hybrid.description.text = reboot_msg;
                     extension.hybrid.description.show();
 
                     extension.intel.description.hide();
                     extension.nvidia.description.hide();
-                } else if (name == "intel") {
+                } else if (name == "Intel") {
                     extension.intel.description.text = reboot_msg;
                     extension.intel.description.show();
 


### PR DESCRIPTION
After switching graphics and choosing not to restart immediately, there's supposed to be a note added in the menu below the newly-selected graphics mode saying "Will be enabled on the next restart".

That note currently always appears on the nvidia menu item, regardless of which mode was (otherwise successfully) enabled.

 