### PR TITLE
Remove call to nonexistent function

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -234,7 +234,6 @@ export class Ext {
     }
 
     destroy() {
-        this.bus.destroy();
         this.battery.destroy();
         this.balanced.destroy();
         this.performance.destroy();


### PR DESCRIPTION
PowerDaemon does not have a `destroy()` function. This would produce an error when the extension was unloaded, such as during suspend, causing gnome-shell to disable it.

Compare: [extension.js](https://github.com/pop-os/gnome-shell-extension-system76-power/blob/5253c21643f57229e3ee269deb5cf408a8f267b8/extension.js#L419-L421)
Resolves: #41