### PR TITLE
update metadata.json for GNOME 40 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,6 +2,6 @@
     "name": "System76 Power",
     "description": "System76 Power Management",
     "uuid": "system76-power@system76.com",
-    "shell-version": ["3.36"],
+    "shell-version": ["3.36", "3.38", "40"],
     "url": "https://github.com/pop-os/gnome-shell-extension-system76-power"
 }


### PR DESCRIPTION
This PR adds support for GNOME 40 from this page though it also adds 3.38 as well just for good measure:

https://gjs.guide/extensions/upgrading/gnome-shell-40.html#contents