### PR TITLE
update metadata for GNOME 41

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,6 +2,6 @@
     "name": "System76 Power",
     "description": "System76 Power Management",
     "uuid": "system76-power@system76.com",
-    "shell-version": ["3.36", "3.38", "40"],
+    "shell-version": ["3.36", "3.38", "40", "41"],
     "url": "https://github.com/pop-os/gnome-shell-extension-system76-power"
 }


### PR DESCRIPTION
Confirmed this works for 22.04