### PR TITLE
fix: remove power profiles menu when enabled

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -95,6 +95,14 @@ function init() {
 // @ts-ignore
 function enable() {
     if (null === ext) {
+        // Remove power profiles menu
+        const menu = Main.panel.statusArea['aggregateMenu']
+        const powerProfilesMenu = menu._powerProfiles
+        if (powerProfilesMenu) {
+            menu._indicators.remove_child(powerProfilesMenu)
+            menu.menu.box.remove_child(powerProfilesMenu.menu.actor)
+        }
+
         ext = new Ext();
     }
 }


### PR DESCRIPTION
To be merged alongside https://github.com/pop-os/system76-power/pull/430
Removes the power profiles menu that will appear once system76-power begins offering the `net.hadess.PowerProfiles` interface.